### PR TITLE
Merge dashLogger and logger, create two separate logging transports to replicate dashLogger functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@elastic/elasticsearch": "7.17.0",
+        "@elastic/elasticsearch": "^7.17.0",
         "@google-cloud/storage": "^7.7.0",
         "axios": "^1.6.5",
         "dotenv": "^16.3.2",
@@ -20,10 +20,8 @@
       },
       "devDependencies": {
         "@tsconfig/node18-strictest-esm": "^1.0.1",
-        "@types/elasticsearch": "^5.0.40",
         "@types/json2csv": "^5.0.3",
         "@types/node": "^18.11.10",
-        "@types/node-fetch": "^2.6.2",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
         "@typescript-eslint/parser": "^6.19.1",
         "eslint": "^8.56.0",
@@ -366,12 +364,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
-    "node_modules/@types/elasticsearch": {
-      "version": "5.0.40",
-      "resolved": "https://registry.npmjs.org/@types/elasticsearch/-/elasticsearch-5.0.40.tgz",
-      "integrity": "sha512-lhnbkC0XorAD7Dt7X+94cXUSHEdDNnEVk/DgFLHgIZQNhixV631Lj4+KpXunTT5rCHyj9RqK3TfO7QrOiwEeUQ==",
-      "dev": true
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -404,30 +396,6 @@
       "version": "18.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
       "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/@types/request": {
       "version": "2.48.12",
@@ -4312,12 +4280,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
-    "@types/elasticsearch": {
-      "version": "5.0.40",
-      "resolved": "https://registry.npmjs.org/@types/elasticsearch/-/elasticsearch-5.0.40.tgz",
-      "integrity": "sha512-lhnbkC0XorAD7Dt7X+94cXUSHEdDNnEVk/DgFLHgIZQNhixV631Lj4+KpXunTT5rCHyj9RqK3TfO7QrOiwEeUQ==",
-      "dev": true
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -4350,29 +4312,6 @@
       "version": "18.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
       "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
-    },
-    "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
     },
     "@types/request": {
       "version": "2.48.12",

--- a/src/helpers/cdcInfoAPI.ts
+++ b/src/helpers/cdcInfoAPI.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { logger, dashLogger } from "./logger.js";
+import { logger } from "./logger.js";
 import { requestHeaders } from "./cdcStagingConn.js";
 
 const maxRetries = 10;
@@ -13,7 +13,7 @@ export async function getCDCApiInfo(id: string, lang: string, host: string) {
     try {
       const cdcApiRes = await axios.get(requestUrl, { headers: requestHeaders });
 
-      logger.info(`CDC Internal API statusCode: ${cdcApiRes.status}`);
+      logger.info("CDC Internal API statusCode: %s", cdcApiRes.status);
       let publisher: string | undefined = cdcApiRes.data.publisherFilter.publisher;
       let studyNumber: string | undefined = cdcApiRes.data.studyNumber;
 
@@ -32,12 +32,10 @@ export async function getCDCApiInfo(id: string, lang: string, host: string) {
       };
     }
     catch (error) {
-      logger.error(`Error at CDC Internal API Fetch: ${error}`);
-      dashLogger.error(`Error at CDC Internal API Fetch: ${error}, URL:${requestUrl}, time:${new Date().toUTCString()}`);
+      logger.error("Error at CDC Internal API Fetch: %s", error);
 
       if (retries++ >= maxRetries) {
-        logger.error(`Too many request retries on internal CDC API.`);
-        dashLogger.error(`Too many request retries on internal CDC API, URL:${requestUrl}, time:${new Date().toUTCString()}`);
+        logger.error("Too many request retries on internal CDC API.");
         return {
           publisher: "NOT-FETCHED-CDC-PUBLISHER",
           studyNumber: "NOT-FETCHED-CDC-STUDYNUMBER"

--- a/src/helpers/esFunctions.ts
+++ b/src/helpers/esFunctions.ts
@@ -1,5 +1,5 @@
 import { Client } from '@elastic/elasticsearch';
-import { logger, dashLogger } from "./logger.js";
+import { logger } from "./logger.js";
 
 // Elasticsearch Client - Defaults to localhost if true and unspecified
 const elasticsearchUrl = process.env['PASC_ELASTICSEARCH_URL'] || "http://localhost:9200/";
@@ -46,10 +46,9 @@ export async function resultsToElastic(fileName: string, assessResults: string |
         assessResults
       }
     });
-    logger.info(`inserted successfully in ES: ${fileName}`);
+    logger.debug("inserted successfully in ES: %s", fileName);
   }
   catch (error) {
-    logger.error(`error in insert to ES: ${error}, filename:${fileName}`);
-    dashLogger.error(`error in insert to ES: ${error}, filename:${fileName}, time:${new Date().toUTCString()}`);
+    logger.error("error in insert to ES: %s, filename: %s", error, fileName);
   }
 }

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -1,4 +1,4 @@
-import winston, { transports as _transports, createLogger } from "winston";
+import winston, { transports as _transports } from "winston";
 import "winston-daily-rotate-file";
 
 const logLevel = process.env['SEARCHKIT_LOG_LEVEL'] || 'info';
@@ -12,6 +12,19 @@ function loggerFormat() {
   }
 }
 
+const commonSettings: winston.transport.TransportStreamOptions = {
+  handleExceptions: true,
+  handleRejections: true
+};
+
+const dashLog = new _transports.DailyRotateFile({
+  ...commonSettings,
+  filename: "../outputs/logs/dash-%DATE%.log",
+  datePattern: "YYYY-MM-DD",
+  zippedArchive: true,
+  maxSize: "20m"
+});
+
 export const logger = winston.createLogger({
   level: logLevel,
   format: winston.format.combine(
@@ -20,23 +33,7 @@ export const logger = winston.createLogger({
     loggerFormat()
   ),
   transports: [
-    new winston.transports.Console()
-  ],
-  exceptionHandlers: [
-    new winston.transports.Console()
-  ],
-});
-
-const dashLog = new _transports.DailyRotateFile({
-  filename: "../outputs/logs/dash-%DATE%.log",
-  datePattern: "YYYY-MM-DD",
-  zippedArchive: true,
-  maxSize: "20m",
-});
-const dash = createLogger({
-  transports: [
+    new winston.transports.Console(commonSettings),
     dashLog
-  ],
+  ]
 });
-
-export const dashLogger = dash;

--- a/src/helpers/writeToCSV.ts
+++ b/src/helpers/writeToCSV.ts
@@ -94,6 +94,6 @@ export function resultsToCSV(csvData: Readable, filename: string, csvType: strin
     const opts = { fields };
     const json2csv = new Transform(opts, { objectMode: true });
     const processor = csvData.pipe(json2csv).pipe(outputLocal);
-    parseAsync(processor, opts).catch(err => logger.error(`CSV writer Error: ${err}`));
+    parseAsync(processor, opts).catch(err => logger.error("CSV writer Error: %s", err));
     //uploadFromMemory(fileName, fujiResults).catch0(console.error); //Write-to-Cloud-Bucket function
 }

--- a/src/helpers/writeToFiles.ts
+++ b/src/helpers/writeToFiles.ts
@@ -1,6 +1,6 @@
 import { Storage } from '@google-cloud/storage';
 import { writeFile } from 'fs';
-import { dashLogger, logger } from "./logger.js";
+import { logger } from "./logger.js";
 // Create a google client with explicit credentials - jsonFile
 /*const storage = new Storage({
     projectId: 'cessda-dev',
@@ -33,11 +33,10 @@ export async function uploadFromMemory(fileName: string, assessResults: Buffer) 
 export function resultsToHDD(dir: string, fileName: string, assessResults: string | JSON) {
   writeFile(`${dir}/${fileName}`, JSON.stringify(assessResults, null, 4), (err) => {
     if (err) {
-      logger.error(`Error writing to file: ${err}, filename:${fileName}`);
-      dashLogger.error(`Error writing to file: ${err}, filename:${fileName}, time:${new Date().toUTCString()}`);
+      logger.error("Error writing to file %s: %s", fileName, err);
     }
     else {
-      logger.info(`File written successfully: ${fileName}`);
+        logger.info("File written successfully: %s", fileName);
     }
   });
 }

--- a/src/sitemaps.ts
+++ b/src/sitemaps.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { URL } from 'url';
 import { getStudiesAssess } from './helpers/studiesAssessment.js';
-import { dashLogger, logger } from "./helpers/logger.js";
+import { logger } from "./helpers/logger.js";
 import { getStudiesFromSitemap } from "./helpers/fetchSitemapStudies.js";
 import { elasticIndexCheck } from './helpers/esFunctions.js';
 import { open, readFile, unlink } from 'fs/promises';
@@ -9,7 +9,6 @@ dotenv.config({ path: '../.env' })
 
 //START SCRIPT EXECUTION
 logger.info('Start of Script');
-dashLogger.info(`Start of Script, time:${new Date().toUTCString()}`);
 //creates ES index if it doesnt exist, skips creating if it does exist
 await elasticIndexCheck();
 //check if failed.txt exists from previous run, and remove it for a clear run
@@ -21,28 +20,24 @@ try {
 const file = await open('../inputs/sitemapsRUN.txt', 'r');
 //for each sitemap line of file input, begin loop
 for await (const sitemapLine of file.readLines()) {
-  logger.info(`Processing sitemap: ${sitemapLine}`);
-  dashLogger.info(`Processing sitemap: ${sitemapLine}, time:${new Date().toUTCString()}`);
+  logger.info("Processing sitemap: %s", sitemapLine);
   const studiesAssessFiltered: string[] = await getStudiesFromSitemap(new URL(sitemapLine));
+  logger.info("Studies to Assess: %d", studiesAssessFiltered.length);
   const outputName: string = new URL(sitemapLine).hostname;
   await getStudiesAssess(studiesAssessFiltered, outputName);
-  logger.info(`Finished assessing sitemap: ${sitemapLine}`);
-  dashLogger.info(`Finished assessing sitemap: ${sitemapLine}, time:${new Date().toUTCString()}`);
+  logger.info("Finished assessing sitemap: %s", sitemapLine);
 }
 
 //check file if any studies failed and re-assess them
 try {
   const studiesAssessFailed: string[] = (await readFile('../outputs/failed.txt')).toString().replace(/\r\n/g, '\n').split('\n');
   if (studiesAssessFailed.length > 0) {
-    logger.info(`Begin assessing failed studies`);
-    dashLogger.info(`Begin assessing failed studies, time:${new Date().toUTCString()}`);
+    logger.info("Begin assessing failed studies");
     studiesAssessFailed.pop(); //removes last (empty [/n]) element
     await getStudiesAssess(studiesAssessFailed, "failed");
   }
 } catch (err) {
-  logger.info(`Error while checking failed.txt, ${err}`);
-  dashLogger.info(`Error while checking failed.txt, ${err}, time:${new Date().toUTCString()}`);
+  logger.info("Error while checking failed.txt", err);
 }
 
 logger.info('End of Script');
-dashLogger.info(`End of Script, time:${new Date().toUTCString()}`);

--- a/src/studies.ts
+++ b/src/studies.ts
@@ -1,13 +1,13 @@
 import * as dotenv from 'dotenv'
 import { readFile, unlink } from 'fs/promises';
 import { getStudiesAssess } from './helpers/studiesAssessment.js';
-import { dashLogger, logger } from "./helpers/logger.js";
+import { logger } from "./helpers/logger.js";
 import { elasticIndexCheck } from './helpers/esFunctions.js';
 dotenv.config({ path: '../.env' });
 
 //START SCRIPT EXECUTION
 logger.info('Start of Script');
-dashLogger.info(`Start of Script, time:${new Date().toUTCString()}`);
+
 //creates ES index if it doesnt exist, skips creating if it does exist
 await elasticIndexCheck();
 
@@ -23,21 +23,17 @@ const studiesAssess: string[] = (studiesRUN).toString().replace(/\r\n/g, '\n').s
 const outputName: string = "StudiesAssessment";
 await getStudiesAssess(studiesAssess, outputName);
 logger.info(`Finished assessing studies`);
-dashLogger.info(`Finished assessing studies, time:${new Date().toUTCString()}`);
 
 //check file if any studies failed and re-assess them
 try {
   const studiesAssessFailed: string[] = (await readFile('../outputs/failed.txt')).toString().replace(/\r\n/g, '\n').split('\n');
   if (studiesAssessFailed.length > 0) {
-    logger.info(`Begin assessing failed studies`);
-    dashLogger.info(`Begin assessing failed studies, time:${new Date().toUTCString()}`);
+    logger.info("Begin assessing failed studies");
     studiesAssessFailed.pop(); //removes last (empty [/n]) element
     await getStudiesAssess(studiesAssessFailed, "failed");
   }
 } catch (err) {
-  logger.info(`Error while checking failed.txt, ${err}`);
-  dashLogger.info(`Error while checking failed.txt, ${err}, time:${new Date().toUTCString()}`);
+  logger.info("Error while checking failed.txt, %s", err);
 }
 
 logger.info('End of Script');
-dashLogger.info(`End of Script, time:${new Date().toUTCString()}`);


### PR DESCRIPTION
Logging was done via two separate loggers, resulting in logging code being needlessly duplicated.