### PR TITLE
Add the ability to convert FAIR JSON results into a CSV

### DIFF
--- a/inputs/sitemapsRUN.txt
+++ b/inputs/sitemapsRUN.txt
@@ -1,1 +1,1 @@
-https://www.sodha.be/sitemap.xml
+https://datacatalogue.cessda.eu/sitemap_index.xml

--- a/src/createCSV.ts
+++ b/src/createCSV.ts
@@ -1,0 +1,20 @@
+import { opendir, readFile } from "fs/promises";
+import { resultsToCSV } from "./helpers/writeToCSV.js";
+import { Readable } from "stream";
+
+// Create a CSV from a directory of evaluated FAIR results
+
+const runDate = new Date();
+const assessDate = [runDate.getFullYear(), runDate.getMonth() + 1, runDate.getDate(), runDate.getHours(), runDate.getMinutes(), runDate.getSeconds()].join('-');
+
+const studiesList = new Readable({ objectMode: true })
+studiesList._read = () => { };
+
+const studiesDir = await opendir("../outputs/datacatalogue.cessda.eu");
+for await (const entry of studiesDir) {
+	const text = await readFile(entry.path + '/' + entry.name, {encoding: "utf-8"});
+	const study = JSON.parse(text);
+	studiesList.push(study);
+}
+
+resultsToCSV(studiesList, "StudiesAssessment_" + assessDate, "FUJI");

--- a/src/helpers/cdcInfoAPI.ts
+++ b/src/helpers/cdcInfoAPI.ts
@@ -13,7 +13,7 @@ export async function getCDCApiInfo(id: string, lang: string, host: string) {
     try {
       const cdcApiRes = await axios.get(requestUrl, { headers: requestHeaders });
 
-      logger.info("CDC Internal API statusCode: %s", cdcApiRes.status);
+      logger.debug("CDC Internal API statusCode: %s", cdcApiRes.status);
       let publisher: string | undefined = cdcApiRes.data.publisherFilter.publisher;
       let studyNumber: string | undefined = cdcApiRes.data.studyNumber;
 

--- a/src/helpers/esFunctions.ts
+++ b/src/helpers/esFunctions.ts
@@ -19,7 +19,7 @@ const client = elasticsearchUsername && elasticsearchPassword ? new Client({
 
 
 export async function elasticIndexCheck() {
-  const { body: exists } = await client.indices.exists({ index: 'fair-results' })
+  const exists = await client.indices.exists({ index: 'fair-results' })
   if (!exists) {
     await client.indices.create({
       index: 'fair-results',
@@ -42,7 +42,7 @@ export async function resultsToElastic(fileName: string, assessResults: string |
     await client.index({
       index: 'fair-results',
       id: fileName,
-      body: {
+      document: {
         assessResults
       }
     });

--- a/src/helpers/evaAPI.ts
+++ b/src/helpers/evaAPI.ts
@@ -47,11 +47,11 @@ export async function getEVAResults(studyInfo: StudyInfo): Promise<JSON | string
   evaObjResults['publisher'] = studyInfo.publisher;
   evaObjResults['dateID'] = "EVARun-" + studyInfo.assessDate;
   // TODO: CHECK FOR OTHER SP'S URI PARAMS
-  if (studyInfo.url?.includes("datacatalogue.cessda.eu") || studyInfo.url?.includes("datacatalogue-staging.cessda.eu")) {
+  if (studyInfo.url.hostname === "datacatalogue.cessda.eu" || studyInfo.url.hostname === "datacatalogue-staging.cessda.eu") {
     evaObjResults['uid'] = studyInfo.urlParams?.get('q') + "-" + studyInfo.urlParams?.get('lang') + "-" + studyInfo.assessDate;
     evaObjResults['pid'] = studyInfo.cdcStudyNumber;
   }
-  else if (studyInfo.url?.includes("snd.gu.se") || studyInfo.url?.includes("adp.fdv.uni-lj")) {
+  else if (studyInfo.url.hostname === "snd.gu.se" || studyInfo.url.hostname === "adp.fdv.uni-lj") {
     evaObjResults['uid'] = studyInfo.spID + "-" + studyInfo.assessDate;
     evaObjResults['pid'] = studyInfo.spID;
   }
@@ -62,6 +62,7 @@ export async function getEVAResults(studyInfo: StudyInfo): Promise<JSON | string
   return evaObjResults;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getTotals(objTotals: any) {
   let result_points: number = 0;
   let weight_of_tests: number = 0;

--- a/src/helpers/fetchSitemapStudies.ts
+++ b/src/helpers/fetchSitemapStudies.ts
@@ -1,39 +1,44 @@
-import Sitemapper, { type SitemapperResponse } from 'sitemapper';
+import Sitemapper from 'sitemapper';
 import { requestHeaders } from "./cdcStagingConn.js";
 
-export async function getStudiesFromSitemap(sitemapLine: URL): Promise<string[]> {
+export async function getStudiesFromSitemap(sitemapLine: URL): Promise<URL[]> {
+
     //prepare request for gathering all URL's from the sitemap
     const cdcLinks = new Sitemapper({
         url: sitemapLine.toString(),
         timeout: 5000, // 5 seconds,
         requestHeaders
     });
-    let sitemapRes: SitemapperResponse;
+
     try {
-        sitemapRes = await cdcLinks.fetch();
+        // Parse the sitemap
+        const sitemapRes = await cdcLinks.fetch();
+
+        // TODO: `REMOVE URL's THAT DONT CONTAIN STUDIES FOR ASSESSMENT (LIKE VALID IDENTIFIER IN URL, ETC)
+        const sites = sitemapRes.sites.map(url => new URL(url));
+        switch (sitemapLine.hostname) {
+            //Dataverse Cases
+            case "data.aussda.at":
+            case "datacatalogue.sodanet.gr":
+            case "ssh.datastations.nl":
+            case "www.sodha.be":
+                return sites.filter(site => site.pathname.includes("persistentId"));
+            case "datacatalogue.cessda.eu":
+            case "datacatalogue-staging.cessda.eu":
+                // Only return studies
+                return sites.filter(site => site.pathname === '/detail');
+            case "www.adp.fdv.uni-lj.si":
+                return sites.filter(site => site.pathname.includes("opisi"));
+            case "snd.gu.se":
+                return sites;
+            default:
+                return [];
+    }
     }
     catch (error) {
         throw new SitemapError(`Error at sitemapper fetch: ${error}`, { cause: error });
     }
-    // TODO: `REMOVE URL's THAT DONT CONTAIN STUDIES FOR ASSESSMENT (LIKE VALID IDENTIFIER IN URL, ETC)
-    switch (sitemapLine.hostname) {
-        //Dataverse Cases
-        case "data.aussda.at":
-        case "datacatalogue.sodanet.gr":
-        case "ssh.datastations.nl":
-        case "www.sodha.be":
-            return sitemapRes.sites.filter(site => site.includes("persistentId"));
-        case "datacatalogue.cessda.eu":
-            return sitemapRes.sites.filter(site => site !== 'https://datacatalogue.cessda.eu/');
-        case "datacatalogue-staging.cessda.eu":
-            return sitemapRes.sites.filter(site => site !== 'https://datacatalogue-staging.cessda.eu/');
-        case "www.adp.fdv.uni-lj.si":
-            return sitemapRes.sites.filter(site => site.includes("opisi"));
-        case "snd.gu.se":
-            return sitemapRes.sites;
-        default:
-            return [];
-    }
+
 }
 
 export class SitemapError extends Error {

--- a/src/helpers/fujiAPI.ts
+++ b/src/helpers/fujiAPI.ts
@@ -5,7 +5,10 @@ import { base64UsernamePassword } from "./cdcStagingConn.js";
 import type { StudyInfo } from "../types/studyinfo.js";
 
 const maxRetries = 10;
+
 const fujiEndpoint = process.env['FUJI_API_LOCAL'] || 'http://localhost:1071/fuji/api/v1/evaluate';
+const fujiUsername = process.env['FUJI_USERNAME_LOCAL'] || "marvel";
+const fujiPassword = process.env['FUJI_PASSWORD_LOCAL'] || "wonderwoman";
 
 
 export async function getFUJIResults(studyInfo: StudyInfo): Promise<JSON | string> {
@@ -24,8 +27,8 @@ export async function getFUJIResults(studyInfo: StudyInfo): Promise<JSON | strin
         "auth_token_type": "Basic"
       }, {
         auth: {
-          username: process.env['FUJI_USERNAME_LOCAL'] || "marvel",
-          password: process.env['FUJI_PASSWORD_LOCAL'] || "wonderwoman"
+          username: fujiUsername,
+          password: fujiPassword
         }
       });
       fujiResults = fujiRes.data;
@@ -62,11 +65,11 @@ export async function getFUJIResults(studyInfo: StudyInfo): Promise<JSON | strin
   fujiResults['publisher'] = studyInfo.publisher;
   fujiResults['dateID'] = "FujiRun-" + studyInfo.assessDate;
   // TODO: CHECK FOR OTHER SP'S URI PARAMS
-  if (studyInfo.url.includes("datacatalogue.cessda.eu") || studyInfo.url.includes("datacatalogue-staging.cessda.eu")) {
+  if (studyInfo.url.hostname === "datacatalogue.cessda.eu" || studyInfo.url.hostname === "datacatalogue-staging.cessda.eu") {
     fujiResults['uid'] = studyInfo.urlParams.get('q') + "-" + studyInfo.urlParams.get('lang') + "-" + studyInfo.assessDate;
     fujiResults['pid'] = studyInfo.cdcStudyNumber;
   }
-  else if (studyInfo.url.includes("snd.gu.se") || studyInfo.url.includes("adp.fdv.uni-lj")) {
+  else if (studyInfo.url.hostname === "snd.gu.se" || studyInfo.url.hostname === "adp.fdv.uni-lj") {
     fujiResults['uid'] = studyInfo.spID + "-" + studyInfo.assessDate;
     fujiResults['pid'] = studyInfo.spID;
   }

--- a/src/helpers/studiesAssessment.ts
+++ b/src/helpers/studiesAssessment.ts
@@ -8,7 +8,7 @@ import { mkdir } from 'fs/promises';
 import { logger } from "./logger.js";
 import type { StudyInfo } from '../types/studyinfo.js';
 
-export async function getStudiesAssess(studiesAssessFiltered: string[], outputName: string): Promise<void> {
+export async function getStudiesAssess(studiesAssessFiltered: URL[], outputName: string): Promise<void> {
     //create date of testing
     const runDate = new Date();
     const assessDate = [runDate.getFullYear(), runDate.getMonth() + 1, runDate.getDate(), runDate.getHours(), runDate.getMinutes(), runDate.getSeconds()].join('-');
@@ -55,8 +55,7 @@ export async function getStudiesAssess(studiesAssessFiltered: string[], outputNa
     resultsToCSV(csvFUJI, outputName + "_" + assessDate, "FUJI");
 }
 
-async function getStudyInfo(study: string, assessDate: string): Promise<StudyInfo> {
-    const studyURL = new URL(study);
+async function getStudyInfo(studyURL: URL, assessDate: string): Promise<StudyInfo> {
     const urlParams = studyURL.searchParams;
     const urlPath = studyURL.pathname.substring(1);
 
@@ -72,8 +71,8 @@ async function getStudyInfo(study: string, assessDate: string): Promise<StudyInf
                 fileName: urlParams.get('q') + "-" + urlParams.get('lang') + "-" + assessDate,
                 cdcStudyNumber: temp.studyNumber,
                 publisher: temp.publisher,
-                oaiLink: study.includes("datacatalogue.cessda.eu") ? "https://datacatalogue.cessda.eu/oai-pmh/v0/oai" : "https://datacatalogue-staging.cessda.eu/oai-pmh/v0/oai",
-                url: study,
+                oaiLink: studyURL.host === "datacatalogue.cessda.eu" ? "https://datacatalogue.cessda.eu/oai-pmh/v0/oai" : "https://datacatalogue-staging.cessda.eu/oai-pmh/v0/oai",
+                url: studyURL,
                 urlParams: urlParams,
                 urlPath: urlPath,
             };
@@ -88,7 +87,7 @@ async function getStudyInfo(study: string, assessDate: string): Promise<StudyInf
                 fileName: urlPath.replaceAll('/', '-') + "-" + assessDate,
                 publisher: studyURL.hostname,
                 oaiLink: "https://www.adp.fdv.uni-lj.si/v0/oai",
-                url: study,
+                url: studyURL,
                 urlParams: urlParams,
                 urlPath: urlPath,
             };
@@ -103,7 +102,7 @@ async function getStudyInfo(study: string, assessDate: string): Promise<StudyInf
                 assessDate: assessDate,
                 cdcID: undefined,
                 cdcStudyNumber: undefined,
-                url: study,
+                url: studyURL,
                 urlParams: urlParams,
                 urlPath: urlPath,
             };
@@ -118,7 +117,7 @@ async function getStudyInfo(study: string, assessDate: string): Promise<StudyInf
                 assessDate: assessDate,
                 cdcID: undefined,
                 cdcStudyNumber: undefined,
-                url: study,
+                url: studyURL,
                 urlParams: urlParams,
                 urlPath: urlPath,
             };

--- a/src/helpers/writeToCSV.ts
+++ b/src/helpers/writeToCSV.ts
@@ -4,7 +4,7 @@ import { parseAsync } from "json2csv";
 import { WriteStream, createWriteStream } from 'fs';
 import type { Readable } from "stream";
 
-export function resultsToCSV(csvData: Readable, filename: string, csvType: string) {
+export function resultsToCSV(csvData: Readable, filename: string, csvType: "FUJI" | "EVA" = "FUJI") {
     csvData.push(null);
     let fields: string[] = [];
     let outputLocal: WriteStream;
@@ -63,8 +63,7 @@ export function resultsToCSV(csvData: Readable, filename: string, csvType: strin
             'uid',
             'pid'
         ];
-    }
-    else{
+    } else {
         outputLocal = createWriteStream(`../outputs/${filename}-FUJI.csv`, { encoding: 'utf8' });
         fields = [
             'summary.score_percent.A',

--- a/src/helpers/writeToFiles.ts
+++ b/src/helpers/writeToFiles.ts
@@ -36,7 +36,7 @@ export function resultsToHDD(dir: string, fileName: string, assessResults: strin
       logger.error("Error writing to file %s: %s", fileName, err);
     }
     else {
-        logger.info("File written successfully: %s", fileName);
+        logger.debug("File written successfully: %s", fileName);
     }
   });
 }

--- a/src/sitemaps.ts
+++ b/src/sitemaps.ts
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv';
-import { URL } from 'url';
 import { getStudiesAssess } from './helpers/studiesAssessment.js';
 import { logger } from "./helpers/logger.js";
 import { getStudiesFromSitemap } from "./helpers/fetchSitemapStudies.js";
@@ -7,30 +6,42 @@ import { elasticIndexCheck } from './helpers/esFunctions.js';
 import { open, readFile, unlink } from 'fs/promises';
 dotenv.config({ path: '../.env' })
 
+const failedStudiesLogPath = '../outputs/failed.txt';
+
 //START SCRIPT EXECUTION
 logger.info('Start of Script');
+
 //creates ES index if it doesnt exist, skips creating if it does exist
+//TODO: conditionally enable Elasticsearch support
 await elasticIndexCheck();
+
 //check if failed.txt exists from previous run, and remove it for a clear run
+//TODO: only remove on successful reevaluation
 try {
-  await unlink('../outputs/failed.txt');
+  await unlink(failedStudiesLogPath);
 } catch (err) {
   // ignore
 }
+
 const file = await open('../inputs/sitemapsRUN.txt', 'r');
 //for each sitemap line of file input, begin loop
 for await (const sitemapLine of file.readLines()) {
+  // Parse sitemap
   logger.info("Processing sitemap: %s", sitemapLine);
-  const studiesAssessFiltered: string[] = await getStudiesFromSitemap(new URL(sitemapLine));
+  const studiesAssessFiltered = await getStudiesFromSitemap(new URL(sitemapLine));
+
   logger.info("Studies to Assess: %d", studiesAssessFiltered.length);
-  const outputName: string = new URL(sitemapLine).hostname;
+
+  // Assess each study
+  const outputName = new URL(sitemapLine).hostname;
   await getStudiesAssess(studiesAssessFiltered, outputName);
+
   logger.info("Finished assessing sitemap: %s", sitemapLine);
 }
 
 //check file if any studies failed and re-assess them
 try {
-  const studiesAssessFailed: string[] = (await readFile('../outputs/failed.txt')).toString().replace(/\r\n/g, '\n').split('\n');
+  const studiesAssessFailed = (await readFile(failedStudiesLogPath)).toString().replace(/\r\n/g, '\n').split('\n').map(u => new URL(u));
   if (studiesAssessFailed.length > 0) {
     logger.info("Begin assessing failed studies");
     studiesAssessFailed.pop(); //removes last (empty [/n]) element

--- a/src/studies.ts
+++ b/src/studies.ts
@@ -19,14 +19,14 @@ try {
 }
 
 const studiesRUN = await readFile('../inputs/studiesRUN.txt');
-const studiesAssess: string[] = (studiesRUN).toString().replace(/\r\n/g, '\n').split('\n');
+const studiesAssess = (studiesRUN).toString().replace(/\r\n/g, '\n').split('\n').map(u => new URL(u));
 const outputName: string = "StudiesAssessment";
 await getStudiesAssess(studiesAssess, outputName);
 logger.info(`Finished assessing studies`);
 
 //check file if any studies failed and re-assess them
 try {
-  const studiesAssessFailed: string[] = (await readFile('../outputs/failed.txt')).toString().replace(/\r\n/g, '\n').split('\n');
+  const studiesAssessFailed = (await readFile('../outputs/failed.txt')).toString().replace(/\r\n/g, '\n').split('\n').map(u => new URL(u));
   if (studiesAssessFailed.length > 0) {
     logger.info("Begin assessing failed studies");
     studiesAssessFailed.pop(); //removes last (empty [/n]) element

--- a/src/types/studyinfo.ts
+++ b/src/types/studyinfo.ts
@@ -1,5 +1,5 @@
 export interface StudyInfo {
-  url: string,
+  url: URL,
   urlParams: URLSearchParams,
   urlPath: string,
   publisher: string | undefined,


### PR DESCRIPTION
This commit adds a script, `createCSV.ts`, that takes an output directory of FAIR assessments and creates a CSV with a summary of the results.

This commit also refactors the script and cleans up the codebase.